### PR TITLE
Replaced runCommand with db.command function

### DIFF
--- a/mqemitter-mongodb.js
+++ b/mqemitter-mongodb.js
@@ -58,7 +58,8 @@ function MQEmitterMongoDB (opts) {
         }, start)
       } else if (!capped) {
         // the collection is not capped, make it so
-        that._collection.runCommand('convertToCapped', {
+        that._db.command({
+          convertToCapped: opts.collection,
           size: opts.size,
           max: opts.max
         }, start)


### PR DESCRIPTION
This would otherwise break mqemitter if the collection was already present and not capped.
