### PR TITLE
Fixed mongodb deprecation warnings

### DIFF
--- a/mqemitter-mongodb.js
+++ b/mqemitter-mongodb.js
@@ -32,7 +32,7 @@ function MQEmitterMongoDB (opts) {
     that._db = opts.db
     waitStartup()
   } else {
-    MongoClient.connect(url, function (err, client) {
+    MongoClient.connect(url, { useNewUrlParser: true }, function (err, client) {
       if (err) {
         return that.status.emit('error', err)
       }
@@ -148,7 +148,7 @@ MQEmitterMongoDB.prototype.emit = function (obj, cb) {
       throw err
     }
   } else {
-    this._collection.insert(obj, function (err, res) {
+    this._collection.insertOne(obj, function (err, res) {
       if (cb) {
         if (err) {
           cb(err)


### PR DESCRIPTION
Hi, I fixed these deprecation warnings. We use your package in our microservice. These warnings were displayed with stack trace every time when we restarted our microservice while developing.

DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

DeprecationWarning: collection.insert is deprecated. Use insertOne, insertMany or bulkWrite instead.

maybe it would be worth to release this as npm package version 4.0.3
(I just fixed this for locally in my node_modules folder)