### PR TITLE
fix: Better handle of lastId to fix emitter when using with clusters

### DIFF
--- a/mqemitter-mongodb.js
+++ b/mqemitter-mongodb.js
@@ -90,7 +90,9 @@ function MQEmitterMongoDB (opts) {
     } 
 
     that._collection
-    .find({}, { timeout: false, sortValue: {$natural: -1}, limit: 1})
+    .find({}, { timeout: false })
+    .sort({$natural : -1})
+    .limit(1)
     .next(function (err, doc) {
       if(err){
         that.status.emit('error', err)
@@ -103,7 +105,7 @@ function MQEmitterMongoDB (opts) {
 
   function start () {
 
-    that._stream = that._collection.find(that._lastId ? { _id: { $gt: that._lastId } } : null, {
+    that._stream = that._collection.find({ _id: { $gt: that._lastId }}, {
       tailable: true,
       timeout: false,
       awaitData: true,
@@ -163,8 +165,6 @@ MQEmitterMongoDB.prototype.emit = function (obj, cb) {
     err = new Error('MQEmitterMongoDB is closed')
     if (cb) {
       cb(err)
-    } else {
-      throw err
     }
   } else {
     this._collection.insertOne(obj, function (err, res) {

--- a/test.js
+++ b/test.js
@@ -48,6 +48,34 @@ MongoClient.connect(url, { useNewUrlParser: true, useUnifiedTopology: true, w: 1
       })
     })
 
+    test('should fetch last packet id', function (t) {
+      t.plan(5)
+
+      var started = 0
+      var lastId = new mongodb.ObjectId()
+
+      function startInstance (cb) {
+        var mqEmitterMongoDB = MongoEmitter({
+          url: url
+        })
+
+        mqEmitterMongoDB.status.once('stream', function () {
+          t.equal(mqEmitterMongoDB._db.databaseName, dbname)
+          t.ok(true, 'database name is default db name')
+          if (++started === 1) {
+            mqEmitterMongoDB.emit({ topic: 'last/packet', payload: 'I\'m the last', _id: lastId }, mqEmitterMongoDB.close.bind(mqEmitterMongoDB, cb))
+          } else {
+            t.equal(mqEmitterMongoDB._lastId.toString(), lastId.toString(), 'Should fetch last Id')
+            mqEmitterMongoDB.close(cb)
+          }
+        })
+      }
+
+      startInstance(function () {
+        startInstance(t.end.bind(t))
+      })
+    })
+
     test('with database option', function (t) {
       t.plan(2)
 


### PR DESCRIPTION
Seems that manually creating lastId using mongodb method makes the query loose some messages when using with clusters

Fixes #17 