### PR TITLE
fix: fix new ObjectID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-(mqemitter-mongodb&nbsp;&nbsp;![ci](https://github.com/mcollina/mqemitter-mongodb/workflows/ci/badge.svg)
+mqemitter-mongodb&nbsp;&nbsp;![ci](https://github.com/mcollina/mqemitter-mongodb/workflows/ci/badge.svg)
 =================
 
 MongoDB powered [MQEmitter](http://github.com/mcollina/mqemitter).

--- a/mqemitter-mongodb.js
+++ b/mqemitter-mongodb.js
@@ -9,10 +9,6 @@ const MQEmitter = require('mqemitter')
 const { pipeline, Transform } = require('stream')
 const EE = require('events').EventEmitter
 
-function newId () {
-  return ObjectId.createFromTime(Date.now())
-}
-
 function connectClient (url, opts, cb) {
   MongoClient.connect(url, opts)
     .then(client => {
@@ -148,7 +144,7 @@ function MQEmitterMongoDB (opts) {
         .limit(1)
         .toArray()
       const doc = results[0]
-      that._lastObj = doc || { _id: newId() }
+      that._lastObj = doc || { _id: new ObjectId() }
 
       if (!that._lastObj._stringId) {
         that._lastObj._stringId = that._lastObj._id.toString()

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
-    "eslint": "^9.24.0",
+    "eslint": "^9.26.0",
     "neostandard": "^0.12.1"
   },
   "dependencies": {
-    "mongodb": "^6.15.0",
+    "mongodb": "^6.16.0",
     "mqemitter": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MongoDB based MQEmitter",
   "main": "mqemitter-mongodb.js",
   "scripts": {
-    "unit": "node --test test.js",
+    "unit": "node --test --test-timeout=180000 test.js",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run lint && npm run unit",

--- a/test.js
+++ b/test.js
@@ -11,9 +11,6 @@ const dbname = 'mqemitter-test'
 const collectionName = 'pubsub'
 const url = 'mongodb://127.0.0.1/' + dbname
 
-function newId () {
-  return ObjectId.createFromTime(Date.now())
-}
 async function clean (db, cb) {
   const collections = await db.listCollections({ name: collectionName }).toArray()
   if (collections.length > 0) {
@@ -74,7 +71,7 @@ connectClient(url, { w: 1 }, function (err, client) {
       t.plan(3)
 
       let started = 0
-      const lastId = newId()
+      const lastId = new ObjectId()
 
       function startInstance (cb) {
         const mqEmitterMongoDB = MongoEmitter({


### PR DESCRIPTION
This closes: #63 

It turns out that `ObjectId.createFromTime(Date.now())` adds the value of Date.now() to the epoch, resulting in a date in 2064 causing all kinds of problems, just using `new ObjectID()` was enough.

How this was not found in:
- my local testing
- my github  CI
- matteo's github CI (twice, once during merge and once during release of 9.0.0) 

is beyond my comprehension of how things work.
Anyway it seems solved now.

Kind regards,
Hans

